### PR TITLE
Add transformer configuration options and use jfx filechooser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 .project
 
 */.project
+
+*.iml
+/.idea

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.javadeobfuscator</groupId>
 	<artifactId>deobfuscator-gui</artifactId>
 	<url>https://github.com/java-deobfuscator/</url>
-	<version>1.0</version>
+	<version>1.1</version>
 	<name>deobfuscator-gui</name>
 	<description>UI front-end for deobfuscator</description>
 	<dependencies>
@@ -20,17 +20,25 @@
 	</dependencies>
 	<build>
 		<sourceDirectory>src/java</sourceDirectory>
-		<plugins>		
+        <resources>
+            <resource>
+                <directory>src/resources</directory>
+            </resource>
+        </resources>
+		<plugins>
 			<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
+				<version>3.8.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.javadeobfuscator</groupId>
 	<artifactId>deobfuscator-gui</artifactId>
 	<url>https://github.com/java-deobfuscator/</url>
-	<version>1.1</version>
+	<version>4.0</version>
 	<name>deobfuscator-gui</name>
 	<description>UI front-end for deobfuscator</description>
 	<dependencies>

--- a/src/java/com/javadeobfuscator/deobfuscator/ui/TransformerSpecificConfigDialog.java
+++ b/src/java/com/javadeobfuscator/deobfuscator/ui/TransformerSpecificConfigDialog.java
@@ -1,0 +1,224 @@
+package com.javadeobfuscator.deobfuscator.ui;
+
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.swing.InputVerifier;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JTextField;
+
+import com.javadeobfuscator.deobfuscator.ui.component.SynchronousJFXFileChooser;
+import com.javadeobfuscator.deobfuscator.ui.util.SwingUtil;
+import com.javadeobfuscator.deobfuscator.ui.util.TransformerConfigUtil;
+import javafx.stage.FileChooser;
+
+public class TransformerSpecificConfigDialog
+{
+	private TransformerSpecificConfigDialog()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	public static void fill(JDialog jd, TransformerWithConfig tconfig)
+	{
+		try
+		{
+			Container root = jd.getContentPane();
+			Object config = tconfig.getConfig();
+			Set<Field> fields = TransformerConfigUtil.getTransformerConfigFieldsWithSuperclass(config.getClass());
+			int gridY = 0;
+			for (Field field : fields)
+			{
+				System.out.println("field: " + field.getName());
+				field.setAccessible(true);
+				Class<?> fType = field.getType();
+				if (fType == String.class || fType == CharSequence.class)
+				{
+					JLabel label = new JLabel(field.getName() + ':');
+					SwingUtil.registerGBC(root, label, 0, gridY);
+					JTextField textField = new JTextField(1);
+					SwingUtil.registerGBC(root, textField, 1, gridY, 0, 1);
+					label.setLabelFor(textField);
+					textField.addActionListener(e ->
+					{
+						try
+						{
+							field.set(config, TransformerConfigUtil.convertToObj(fType, textField.getText()));
+						} catch (IllegalAccessException illegalAccessException)
+						{
+							illegalAccessException.printStackTrace();
+						}
+					});
+				} else if (fType == File.class)
+				{
+					JLabel label = new JLabel(field.getName());
+					SwingUtil.registerGBC(root, label, 0, gridY);
+
+					File currFile = (File) field.get(config);
+					String path = currFile == null ? "" : currFile.getAbsolutePath();
+					JTextField textField = new JTextField(path, 1);
+					SwingUtil.registerGBC(root, textField, 1, gridY, gbc ->
+					{
+						gbc.weightx = 1;
+						gbc.fill = GridBagConstraints.HORIZONTAL;
+					});
+					label.setLabelFor(textField);
+					textField.addActionListener(e ->
+					{
+						try
+						{
+							field.set(config, TransformerConfigUtil.convertToObj(fType, textField.getText()));
+						} catch (IllegalAccessException ex)
+						{
+							ex.printStackTrace();
+						}
+					});
+
+					JButton fileChooseButton = new JButton("Select");
+					SwingUtil.registerGBC(root, fileChooseButton, 2, gridY);
+					fileChooseButton.addActionListener(e ->
+					{
+						SynchronousJFXFileChooser chooser = new SynchronousJFXFileChooser(() ->
+						{
+							FileChooser ch = new FileChooser();
+							ch.setTitle("Select " + field.getName());
+							ch.getExtensionFilters().addAll(
+									new FileChooser.ExtensionFilter("Jar and Zip files", "*.jar", "*.zip"),
+									new FileChooser.ExtensionFilter("Jar files", "*.jar"),
+									new FileChooser.ExtensionFilter("Zip files", "*.zip"),
+									new FileChooser.ExtensionFilter("Intermediary mapping", "mappings.tiny", "*.tiny"),
+									new FileChooser.ExtensionFilter("SRG mapping", "*.srg", "*.tsrg"),
+									new FileChooser.ExtensionFilter("CSV mapping", "*.csv"),
+									new FileChooser.ExtensionFilter("All Files", "*.*"));
+							try
+							{
+								File prev = (File) field.get(config);
+								if (prev != null)
+								{
+									if (prev.exists())
+										ch.setInitialFileName(prev.getName());
+									if (prev.getParentFile().exists())
+										ch.setInitialDirectory(prev.getParentFile());
+								}
+							} catch (IllegalAccessException ex)
+							{
+								ex.printStackTrace();
+							}
+							return ch;
+						});
+						File file = chooser.showOpenDialog();
+						System.out.println("file = " + file);
+						if (file != null)
+						{
+							try
+							{
+								textField.setText(file.getAbsolutePath());
+								field.set(config, file);
+							} catch (IllegalAccessException ex)
+							{
+								ex.printStackTrace();
+							}
+						}
+					});
+				} else if (fType == boolean.class || fType == Boolean.class)
+				{
+					JCheckBox checkBox = new JCheckBox(field.getName(), (Boolean) field.get(config));
+					SwingUtil.registerGBC(root, checkBox, 0, gridY, 0, 1);
+					checkBox.addActionListener(e ->
+					{
+						try
+						{
+							field.set(config, checkBox.isSelected());
+						} catch (IllegalAccessException ex)
+						{
+							ex.printStackTrace();
+						}
+					});
+				} else if (fType == byte.class || fType == Byte.class)
+				{
+					numberInput(root, config, gridY, field, fType, numberValidator(Byte::parseByte));
+				} else if (fType == short.class || fType == Short.class)
+				{
+					numberInput(root, config, gridY, field, fType, numberValidator(Short::parseShort));
+				} else if (fType == int.class || fType == Integer.class)
+				{
+					numberInput(root, config, gridY, field, fType, numberValidator(Integer::parseInt));
+				} else if (fType == long.class || fType == Long.class)
+				{
+					numberInput(root, config, gridY, field, fType, numberValidator(Long::parseLong));
+				} else if (fType == float.class || fType == Float.class)
+				{
+					numberInput(root, config, gridY, field, fType, numberValidator(Float::parseFloat));
+				} else if (fType == double.class || fType == Double.class)
+				{
+					numberInput(root, config, gridY, field, fType, numberValidator(Double::parseDouble));
+				}
+				++gridY;
+			}
+		} catch (IllegalAccessException ex)
+		{
+			ex.printStackTrace();
+		}
+	}
+
+	public interface ThrowableFunction<I, R, T extends Throwable>
+	{
+		R apply(I i) throws T;
+	}
+
+	private static Predicate<String> numberValidator(ThrowableFunction<String, Number, NumberFormatException> fun)
+	{
+		return s ->
+		{
+			try
+			{
+				fun.apply(s);
+				return true;
+			} catch (NumberFormatException t)
+			{
+				return false;
+			}
+		};
+	}
+
+	private static void numberInput(Container root, Object config, int gridY, Field field, Class<?> fType, Predicate<String> verifier)
+	{
+		JLabel label = new JLabel(field.getName());
+		SwingUtil.registerGBC(root, label, 0, gridY);
+
+		JTextField textField = new JTextField(1);
+		SwingUtil.registerGBC(root, textField, 1, gridY, 0, 1);
+		textField.setInputVerifier(new InputVerifier()
+		{
+			@Override
+			public boolean verify(JComponent input)
+			{
+				return verifier.test(textField.getText());
+			}
+		});
+		label.setLabelFor(textField);
+		textField.addActionListener(e ->
+		{
+			String text = textField.getText();
+			if (!verifier.test(text))
+			{
+				return;
+			}
+			try
+			{
+				field.set(config, TransformerConfigUtil.convertToObj(fType, text));
+			} catch (IllegalAccessException ex)
+			{
+				ex.printStackTrace();
+			}
+		});
+	}
+}

--- a/src/java/com/javadeobfuscator/deobfuscator/ui/TransformerWithConfig.java
+++ b/src/java/com/javadeobfuscator/deobfuscator/ui/TransformerWithConfig.java
@@ -1,0 +1,69 @@
+package com.javadeobfuscator.deobfuscator.ui;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import com.javadeobfuscator.deobfuscator.ui.util.TransformerConfigUtil;
+
+public class TransformerWithConfig
+{
+	private final String shortName;
+	private Object config;
+
+	public TransformerWithConfig(String shortName) {
+		this.shortName = shortName;
+	}
+
+	public TransformerWithConfig(String shortName, Object config) {
+		this.shortName = shortName;
+		this.config = config;
+	}
+
+	public String getShortName()
+	{
+		return shortName;
+	}
+
+	public Object getConfig()
+	{
+		return config;
+	}
+
+	public void setConfig(Object config)
+	{
+		this.config = config;
+	}
+	
+	public String toExportString() {
+		Set<Field> fields = TransformerConfigUtil.getTransformerConfigFieldsWithSuperclass(config.getClass());
+		StringBuilder sb = new StringBuilder(this.shortName);
+		for (Field field : fields)
+		{
+			field.setAccessible(true);
+			try
+			{
+				Object val = field.get(config);
+				if (val == null) {
+					continue;
+				}
+				sb.append(':').append(field.getName()).append('=');
+				if (val instanceof File) {
+					sb.append('"').append(((File) val).getAbsolutePath()).append('"');
+				} else {
+				sb.append(val);
+				}
+			} catch (IllegalAccessException e)
+			{
+				e.printStackTrace();
+			}
+		}
+		return sb.toString();
+	}
+
+	@Override
+	public String toString()
+	{
+		return this.shortName;
+	}
+}

--- a/src/java/com/javadeobfuscator/deobfuscator/ui/component/SynchronousJFXCaller.java
+++ b/src/java/com/javadeobfuscator/deobfuscator/ui/component/SynchronousJFXCaller.java
@@ -1,0 +1,143 @@
+package com.javadeobfuscator.deobfuscator.ui.component;
+
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.swing.JDialog;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+
+/**
+ * A utility class to execute a Callable synchronously on the JavaFX event thread.
+ *
+ * <a href="https://stackoverflow.com/questions/28920758/javafx-filechooser-in-swing">Source</a>
+ *
+ * @param <T> the return type of the callable
+ */
+public class SynchronousJFXCaller<T>
+{
+	public static void init()
+	{
+		new JFXPanel();
+		Platform.setImplicitExit(false);
+	}
+
+	private final Callable<T> callable;
+
+	/**
+	 * Constructs a new caller that will execute the provided callable.
+	 *
+	 * The callable is accessed from the JavaFX event thread, so it should either be immutable or at least its state shouldn't be changed randomly while the call()
+	 * method is in progress.
+	 *
+	 * @param callable the action to execute on the JFX event thread
+	 */
+	public SynchronousJFXCaller(Callable<T> callable)
+	{
+		this.callable = callable;
+	}
+
+	/**
+	 * Executes the Callable.
+	 * <p>
+	 * A specialized task is run using Platform.runLater(). The calling thread then waits first for the task to start, then for it to return a result. Any exception
+	 * thrown by the Callable will be rethrown in the calling thread.
+	 * </p>
+	 *
+	 * @param startTimeout     time to wait for Platform.runLater() to <em>start</em> the dialog-showing task
+	 * @param startTimeoutUnit the time unit of the startTimeout argument
+	 * @return whatever the Callable returns
+	 * @throws IllegalStateException if Platform.runLater() fails to start the task within the given timeout
+	 * @throws InterruptedException  if the calling (this) thread is interrupted while waiting for the task to start or to get its result (note that the task will
+	 *                               still run anyway and its result will be ignored)
+	 */
+	public T call(long startTimeout, TimeUnit startTimeoutUnit)
+			throws Exception
+	{
+		final CountDownLatch taskStarted = new CountDownLatch(1);
+		// Can't use volatile boolean here because only finals can be accessed
+		// from closures like the lambda expression below.
+		final AtomicBoolean taskCancelled = new AtomicBoolean(false);
+		// a trick to emulate modality:
+		final JDialog modalBlocker = new JDialog();
+		modalBlocker.setModal(true);
+		modalBlocker.setUndecorated(true);
+		modalBlocker.setSize(0, 0);
+		modalBlocker.setOpacity(0.0f);
+		modalBlocker.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+		final CountDownLatch modalityLatch = new CountDownLatch(1);
+		final FutureTask<T> task = new FutureTask<>(() ->
+		{
+			synchronized (taskStarted)
+			{
+				if (taskCancelled.get())
+				{
+					return null;
+				} else
+				{
+					taskStarted.countDown();
+				}
+			}
+			try
+			{
+				return callable.call();
+			} finally
+			{
+				// Wait until the Swing thread is blocked in setVisible():
+				modalityLatch.await();
+				// and unblock it:
+				SwingUtilities.invokeLater(modalBlocker::dispose);
+			}
+		});
+		Platform.runLater(task);
+		if (!taskStarted.await(startTimeout, startTimeoutUnit))
+		{
+			synchronized (taskStarted)
+			{
+				// the last chance, it could have been started just now
+				if (!taskStarted.await(0, TimeUnit.MILLISECONDS))
+				{
+					// Can't use task.cancel() here because it would
+					// interrupt the JavaFX thread, which we don't own.
+					taskCancelled.set(true);
+					throw new IllegalStateException("JavaFX was shut down or is unresponsive");
+				}
+			}
+		}
+		// a trick to notify the task AFTER we have been blocked
+		// in setVisible()
+		SwingUtilities.invokeLater(() ->
+		{
+			// notify that we are ready to get the result:
+			modalityLatch.countDown();
+		});
+		modalBlocker.setVisible(true); // blocks
+		modalBlocker.dispose(); // release resources
+		try
+		{
+			return task.get();
+		} catch (ExecutionException ex)
+		{
+			Throwable ec = ex.getCause();
+			if (ec instanceof Exception)
+			{
+				throw (Exception) ec;
+			} else if (ec instanceof Error)
+			{
+				throw (Error) ec;
+			} else
+			{
+				throw new AssertionError("Unexpected exception type", ec);
+			}
+		}
+	}
+}

--- a/src/java/com/javadeobfuscator/deobfuscator/ui/component/SynchronousJFXFileChooser.java
+++ b/src/java/com/javadeobfuscator/deobfuscator/ui/component/SynchronousJFXFileChooser.java
@@ -1,0 +1,135 @@
+package com.javadeobfuscator.deobfuscator.ui.component;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javafx.stage.FileChooser;
+
+/**
+ * A utility class that summons JavaFX FileChooser from the Swing EDT. (Or anywhere else for that matter.) JavaFX should be initialized prior to using this class (e.
+ * g. by creating a JFXPanel instance). It is also recommended to call Platform.setImplicitExit(false) after initialization to ensure that JavaFX platform keeps
+ * running. Don't forget to call Platform.exit() when shutting down the application, to ensure that the JavaFX threads don't prevent JVM exit.
+ *
+ * <a href="https://stackoverflow.com/questions/28920758/javafx-filechooser-in-swing">Source</a>
+ */
+public class SynchronousJFXFileChooser
+{
+	private final Supplier<FileChooser> fileChooserFactory;
+
+	/**
+	 * Constructs a new file chooser that will use the provided factory.
+	 *
+	 * The factory is accessed from the JavaFX event thread, so it should either be immutable or at least its state shouldn't be changed randomly while one of the
+	 * dialog-showing method calls is in progress.
+	 *
+	 * The factory should create and set up the chooser, for example, by setting extension filters. If there is no need to perform custom initialization of the
+	 * chooser, FileChooser::new could be passed as a factory.
+	 *
+	 * Alternatively, the method parameter supplied to the showDialog() function can be used to provide custom initialization.
+	 *
+	 * @param fileChooserFactory the function used to construct new choosers
+	 */
+	public SynchronousJFXFileChooser(Supplier<FileChooser> fileChooserFactory)
+	{
+		this.fileChooserFactory = fileChooserFactory;
+	}
+
+	/**
+	 * Shows the FileChooser dialog by calling the provided method.
+	 *
+	 * Waits for one second for the dialog-showing task to start in the JavaFX event thread, then throws an IllegalStateException if it didn't start.
+	 *
+	 * @param <T>    the return type of the method, usually File or List&lt;File&gt;
+	 * @param method a function calling one of the dialog-showing methods
+	 * @return whatever the method returns
+	 * @see #showDialog(java.util.function.Function, long, java.util.concurrent.TimeUnit)
+	 */
+	public <T> T showDialog(Function<FileChooser, T> method)
+	{
+		return showDialog(method, 1, TimeUnit.SECONDS);
+	}
+
+	/**
+	 * Shows the FileChooser dialog by calling the provided method. The dialog is created by the factory supplied to the constructor, then it is shown by calling
+	 * the
+	 * provided method on it, then the result is returned.
+	 * <p>
+	 * Everything happens in the right threads thanks to {@link SynchronousJFXCaller}. The task performed in the JavaFX thread consists of two steps: construct a
+	 * chooser using the provided factory and invoke the provided method on it. Any exception thrown during these steps will be rethrown in the calling thread, 
+	 * which
+	 * shouldn't normally happen unless the factory throws an unchecked exception.
+	 * </p>
+	 * <p>
+	 * If the calling thread is interrupted during either the wait for the task to start or for its result, then null is returned and the Thread interrupted status
+	 * is set.
+	 * </p>
+	 *
+	 * @param <T>     return type (usually File or List&lt;File&gt;)
+	 * @param method  a function that calls the desired FileChooser method
+	 * @param timeout time to wait for Platform.runLater() to <em>start</em> the dialog-showing task (once started, it is allowed to run as long as needed)
+	 * @param unit    the time unit of the timeout argument
+	 * @return whatever the method returns
+	 * @throws IllegalStateException if Platform.runLater() fails to start the dialog-showing task within the given timeout
+	 */
+	public <T> T showDialog(Function<FileChooser, T> method,
+			long timeout, TimeUnit unit)
+	{
+		Callable<T> task = () ->
+		{
+			FileChooser chooser = fileChooserFactory.get();
+			return method.apply(chooser);
+		};
+		SynchronousJFXCaller<T> caller = new SynchronousJFXCaller<>(task);
+		try
+		{
+			return caller.call(timeout, unit);
+		} catch (RuntimeException | Error ex)
+		{
+			throw ex;
+		} catch (InterruptedException ex)
+		{
+			Thread.currentThread().interrupt();
+			return null;
+		} catch (Exception ex)
+		{
+			throw new AssertionError("Got unexpected checked exception from SynchronousJFXCaller.call()", ex);
+		}
+	}
+
+	/**
+	 * Shows a FileChooser using FileChooser.showOpenDialog().
+	 *
+	 * @return the return value of FileChooser.showOpenDialog()
+	 * @see #showDialog(java.util.function.Function, long, java.util.concurrent.TimeUnit)
+	 */
+	public File showOpenDialog()
+	{
+		return showDialog(chooser -> chooser.showOpenDialog(null));
+	}
+
+	/**
+	 * Shows a FileChooser using FileChooser.showSaveDialog().
+	 *
+	 * @return the return value of FileChooser.showSaveDialog()
+	 * @see #showDialog(java.util.function.Function, long, java.util.concurrent.TimeUnit)
+	 */
+	public File showSaveDialog()
+	{
+		return showDialog(chooser -> chooser.showSaveDialog(null));
+	}
+
+	/**
+	 * Shows a FileChooser using FileChooser.showOpenMultipleDialog().
+	 *
+	 * @return the return value of FileChooser.showOpenMultipleDialog()
+	 * @see #showDialog(java.util.function.Function, long, java.util.concurrent.TimeUnit)
+	 */
+	public List<File> showOpenMultipleDialog()
+	{
+		return showDialog(chooser -> chooser.showOpenMultipleDialog(null));
+	}
+}

--- a/src/java/com/javadeobfuscator/deobfuscator/ui/component/WrapLayout.java
+++ b/src/java/com/javadeobfuscator/deobfuscator/ui/component/WrapLayout.java
@@ -1,0 +1,190 @@
+package com.javadeobfuscator.deobfuscator.ui.component;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Insets;
+
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+
+/**
+ * FlowLayout subclass that fully supports wrapping of components.
+ */
+public class WrapLayout extends FlowLayout
+{
+	private Dimension preferredLayoutSize;
+
+	/**
+	 * Constructs a new <code>WrapLayout</code> with a left alignment and a default 5-unit horizontal and vertical gap.
+	 */
+	public WrapLayout()
+	{
+		super();
+	}
+
+	/**
+	 * Constructs a new <code>FlowLayout</code> with the specified alignment and a default 5-unit horizontal and vertical gap. The value of the alignment argument
+	 * must be one of
+	 * <code>WrapLayout</code>, <code>WrapLayout</code>,
+	 * or <code>WrapLayout</code>.
+	 *
+	 * @param align the alignment value
+	 */
+	public WrapLayout(int align)
+	{
+		super(align);
+	}
+
+	/**
+	 * Creates a new flow layout manager with the indicated alignment and the indicated horizontal and vertical gaps.
+	 * <p>
+	 * The value of the alignment argument must be one of
+	 * <code>WrapLayout</code>, <code>WrapLayout</code>,
+	 * or <code>WrapLayout</code>.
+	 *
+	 * @param align the alignment value
+	 * @param hgap  the horizontal gap between components
+	 * @param vgap  the vertical gap between components
+	 */
+	public WrapLayout(int align, int hgap, int vgap)
+	{
+		super(align, hgap, vgap);
+	}
+
+	/**
+	 * Returns the preferred dimensions for this layout given the
+	 * <i>visible</i> components in the specified target container.
+	 *
+	 * @param target the component which needs to be laid out
+	 * @return the preferred dimensions to lay out the subcomponents of the specified container
+	 */
+	@Override
+	public Dimension preferredLayoutSize(Container target)
+	{
+		return layoutSize(target, true);
+	}
+
+	/**
+	 * Returns the minimum dimensions needed to layout the <i>visible</i> components contained in the specified target container.
+	 *
+	 * @param target the component which needs to be laid out
+	 * @return the minimum dimensions to lay out the subcomponents of the specified container
+	 */
+	@Override
+	public Dimension minimumLayoutSize(Container target)
+	{
+		Dimension minimum = layoutSize(target, false);
+		minimum.width += (getHgap() * 2);
+		return minimum;
+	}
+
+	/**
+	 * Returns the minimum or preferred dimension needed to layout the target container.
+	 *
+	 * @param target    target to get layout size for
+	 * @param preferred should preferred size be calculated
+	 * @return the dimension to layout the target container
+	 */
+	private Dimension layoutSize(Container target, boolean preferred)
+	{
+		synchronized (target.getTreeLock())
+		{
+			//  Each row must fit with the width allocated to the containter.
+			//  When the container width = 0, the preferred width of the container
+			//  has not yet been calculated so lets ask for the maximum.
+
+			Container container = target;
+
+			while ((container == target || container.getSize().width == 0) && container.getParent() != null)
+			{
+				container = container.getParent();
+			}
+
+			int targetWidth = container.getSize().width;
+
+			if (targetWidth == 0)
+				targetWidth = Integer.MAX_VALUE;
+
+			int hgap = getHgap();
+			int vgap = getVgap();
+			Insets insets = target.getInsets();
+			int horizontalInsetsAndGap = insets.left + insets.right + (hgap * 2);
+			int maxWidth = targetWidth - horizontalInsetsAndGap;
+
+			//  Fit components into the allowed width
+
+			Dimension dim = new Dimension(0, 0);
+			int rowWidth = 0;
+			int rowHeight = 0;
+
+			int nmembers = target.getComponentCount();
+
+			for (int i = 0; i < nmembers; i++)
+			{
+				Component m = target.getComponent(i);
+
+				if (m.isVisible())
+				{
+					Dimension d = preferred ? m.getPreferredSize() : m.getMinimumSize();
+
+					//  Can't add the component to current row. Start a new row.
+
+					int compWidth = rowWidth + d.width + hgap * 2 + 2;
+					if (compWidth > maxWidth)
+					{
+						addRow(dim, rowWidth, rowHeight);
+						rowWidth = 0;
+						rowHeight = 0;
+					}
+
+					//  Add a horizontal gap
+					rowWidth += hgap;
+
+					rowWidth += d.width;
+					rowHeight = Math.max(rowHeight, d.height);
+				}
+			}
+
+			addRow(dim, rowWidth, rowHeight);
+
+			dim.width += Math.max(horizontalInsetsAndGap, maxWidth);
+			dim.height += insets.top + insets.bottom + vgap * 2;
+
+			//	When using a scroll pane or the DecoratedLookAndFeel we need to
+			//  make sure the preferred size is less than the size of the
+			//  target containter so shrinking the container size works
+			//  correctly. Removing the horizontal gap is an easy way to do this.
+
+			Container scrollPane = SwingUtilities.getAncestorOfClass(JScrollPane.class, target);
+
+			if (scrollPane != null && target.isValid())
+			{
+				dim.width -= (hgap + 1);
+			}
+
+			return dim;
+		}
+	}
+
+	/*
+	 *  A new row has been completed. Use the dimensions of this row
+	 *  to update the preferred size for the container.
+	 *
+	 *  @param dim update the width and height when appropriate
+	 *  @param rowWidth the width of the row to add
+	 *  @param rowHeight the height of the row to add
+	 */
+	private void addRow(Dimension dim, int rowWidth, int rowHeight)
+	{
+		dim.width = Math.max(dim.width, rowWidth);
+
+		if (dim.height > 0)
+		{
+			dim.height += getVgap();
+		}
+
+		dim.height += rowHeight;
+	}
+}

--- a/src/java/com/javadeobfuscator/deobfuscator/ui/util/SwingUtil.java
+++ b/src/java/com/javadeobfuscator/deobfuscator/ui/util/SwingUtil.java
@@ -1,0 +1,41 @@
+package com.javadeobfuscator.deobfuscator.ui.util;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.Insets;
+import java.util.function.Consumer;
+
+public class SwingUtil
+{
+	public SwingUtil()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	public static void registerGBC(Container parent, Component component, int x, int y) {
+		registerGBC(parent, component, x, y, null);
+	}
+
+	public static void registerGBC(Container parent, Component component, int x, int y, Consumer<GridBagConstraints> consumer) {
+		registerGBC(parent, component, x, y, 1, 1, consumer);
+	}
+
+	public static void registerGBC(Container parent, Component component, int x, int y, int w, int h) {
+		registerGBC(parent, component, x, y, w, h, null);
+	}
+
+	public static void registerGBC(Container parent, Component component, int x, int y, int w, int h, Consumer<GridBagConstraints> consumer) {
+		GridBagConstraints gbc = new GridBagConstraints();
+		gbc.anchor = GridBagConstraints.WEST;
+		gbc.insets = new Insets(10, 10, 10, 10);
+		gbc.gridx = x;
+		gbc.gridy = y;
+		gbc.gridwidth = w;
+		gbc.gridheight = h;
+		if (consumer != null) {
+			consumer.accept(gbc);
+		}
+		parent.add(component, gbc);
+	}
+}

--- a/src/java/com/javadeobfuscator/deobfuscator/ui/util/TransformerConfigUtil.java
+++ b/src/java/com/javadeobfuscator/deobfuscator/ui/util/TransformerConfigUtil.java
@@ -1,0 +1,100 @@
+package com.javadeobfuscator.deobfuscator.ui.util;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import com.javadeobfuscator.deobfuscator.ui.SwingWindow;
+
+public class TransformerConfigUtil
+{
+	private TransformerConfigUtil() {
+		throw new UnsupportedOperationException();
+	}
+
+	public static Field getTransformerConfigFieldWithSuperclass(Class<?> cfgClazz, String fieldName)
+	{
+		if (cfgClazz == null || fieldName == null || cfgClazz.getName().equals("com.javadeobfuscator.deobfuscator.config.TransformerConfig"))
+		{
+			return null;
+		}
+		Field field = null;
+		try
+		{
+			field = cfgClazz.getDeclaredField(fieldName);
+		} catch (NoSuchFieldException ex)
+		{
+			Class<?> superclass = cfgClazz.getSuperclass();
+			return getTransformerConfigFieldWithSuperclass(superclass, fieldName);
+		}
+		return field;
+	}
+
+	public static Set<Field> getTransformerConfigFieldsWithSuperclass(Class<?> cfgClazz)
+	{
+		return getTransformerConfigFielddWithSuperclass0(cfgClazz, new LinkedHashSet<>());
+	}
+
+	private static Set<Field> getTransformerConfigFielddWithSuperclass0(Class<?> cfgClazz, Set<Field> result)
+	{
+		if (cfgClazz == null || cfgClazz.getName().equals("com.javadeobfuscator.deobfuscator.config.TransformerConfig"))
+		{
+			return result;
+		}
+		Collections.addAll(result, cfgClazz.getDeclaredFields());
+		return getTransformerConfigFielddWithSuperclass0(cfgClazz.getSuperclass(), result);
+	}
+
+	public static Object convertToObj(Class<?> fType, String strVal)
+	{
+		Object oval = null;
+		if (fType == String.class || fType == CharSequence.class)
+		{
+			oval = strVal;
+		} else if (fType == File.class)
+		{
+			oval = new File(strVal);
+		} else if (fType == boolean.class || fType == Boolean.class)
+		{
+			oval = Boolean.parseBoolean(strVal);
+		} else if (fType == byte.class || fType == Byte.class)
+		{
+			oval = Byte.parseByte(strVal);
+		} else if (fType == short.class || fType == Short.class)
+		{
+			oval = Short.parseShort(strVal);
+		} else if (fType == int.class || fType == Integer.class)
+		{
+			oval = Integer.parseInt(strVal);
+		} else if (fType == long.class || fType == Long.class)
+		{
+			oval = Long.parseLong(strVal);
+		} else if (fType == float.class || fType == Float.class)
+		{
+			oval = Float.parseFloat(strVal);
+		} else if (fType == double.class || fType == Double.class)
+		{
+			oval = Double.parseDouble(strVal);
+		}
+		return oval;
+	}
+
+	public static Object getConfig(Class<?> transformerClass)
+	{
+		try
+		{
+			Object cfg = SwingWindow.trans.getConfigFor(transformerClass);
+			if (cfg != null && cfg.getClass().getName().equals("com.javadeobfuscator.deobfuscator.config.TransformerConfig"))
+			{
+				return null;
+			}
+			return cfg;
+		} catch (Exception ex)
+		{
+			ex.printStackTrace();
+		}
+		return null;
+	}
+}

--- a/src/java/com/javadeobfuscator/deobfuscator/ui/wrap/Config.java
+++ b/src/java/com/javadeobfuscator/deobfuscator/ui/wrap/Config.java
@@ -22,15 +22,11 @@ public class Config {
 
 	/**
 	 * Set transformers list.
-	 * 
+	 *
 	 * @param trans
-	 * @param classes
+	 * @param transformerConfigs
 	 */
-	public void setTransformers(Transformers trans, List<Class<?>> classes) throws Exception {
-		List<Object> transformerConfigs = new ArrayList<>();
-		for (Class<?> clazz : classes) {
-			transformerConfigs.add(trans.getConfigFor(clazz));
-		}
+	public void setTransformers(Transformers trans, List<Object> transformerConfigs) throws Exception {
 		Reflect.setFieldO(instance, "transformers", transformerConfigs);
 	}
 }

--- a/src/java/com/javadeobfuscator/deobfuscator/ui/wrap/Transformers.java
+++ b/src/java/com/javadeobfuscator/deobfuscator/ui/wrap/Transformers.java
@@ -2,6 +2,7 @@ package com.javadeobfuscator.deobfuscator.ui.wrap;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/java/com/javadeobfuscator/deobfuscator/ui/wrap/WrapperFactory.java
+++ b/src/java/com/javadeobfuscator/deobfuscator/ui/wrap/WrapperFactory.java
@@ -41,7 +41,7 @@ public class WrapperFactory {
 	/**
 	 * Set load strategy to loading from specified jar.
 	 * 
-	 * @param jar
+	 * @param file
 	 *            Deobfuscator program jar.
 	 * @throws IOException
 	 *             Jar could not be read.
@@ -55,7 +55,7 @@ public class WrapperFactory {
 	/**
 	 * Set load strategy to loading from adjacent jar files.
 	 * 
-	 * @param recurse
+	 * @param recursive
 	 *            Check sub-directories of adjacent folders.
 	 */
 	public static void setupJarLoader(boolean recursive) {


### PR DESCRIPTION
- sets version to 4.0
- transformer names shortened even more
- transformer specific configuration can be accessed with right click on a transformer on the right side
- transformer specific configuration can be closed with escape key
- allow multi file choosing for path & libs
- less padding around some elements in section "other configuration"
- buttons for string list choosing are now in the same place as those for path choosing and not slightly changed
- old configs should load fine in new app (new configs not compatible to old version)

jfx filechooser uses new windows api for file selection dialog